### PR TITLE
Critical share math fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ layout: default
 
                 //compute how much one share should be
                 #calc_one_share() {
-                    return math.multiply((1.0/this.n_shares) , this._merged_weights());
+                    return math.multiply((1.0/(this.n_shares + this.n_coop_shares)) , this._merged_weights());
                 }
 
                 //compute total weight to give to co-op


### PR DESCRIPTION
i wasn't counting the number of coop shares in the total number of shares when calculating weight per share. fix that!